### PR TITLE
fixes some tests due to collections db cleanup

### DIFF
--- a/server/.eslintrc.js
+++ b/server/.eslintrc.js
@@ -3,6 +3,7 @@ module.exports = {
     browser: true,
     commonjs: true,
     es6: true,
+    jest: true,
   },
   extends: [
     'airbnb-base',

--- a/server/__tests__/routes.js
+++ b/server/__tests__/routes.js
@@ -1,6 +1,7 @@
 const request = require('supertest');
 const fs = require('fs');
 const path = require('path');
+const router = require('../routes/api/collections');
 
 const server = 'http://localhost:5000';
 
@@ -27,7 +28,7 @@ describe('/:id', () => {
   describe('PUT', () => {
     it('updates collection with provided info', () => {
       return request(server)
-        .put('/api/collections/5ee53832573c6f01f2945b58')
+        .put('/api/collections/5ef81c758e61a78b605e5e70')
         .send({ title: 'Cool resources' })
         .set('Accept', 'application/json')
         .then((response) => {
@@ -50,7 +51,7 @@ describe('/:id', () => {
   describe('GET', () => {
     it('gets collection with given id', () => {
       return request(server)
-        .get('/api/collections/5ee53832573c6f01f2945b58')
+        .get('/api/collections/5ef81c758e61a78b605e5e70')
         .then((response) => {
           expect(response.body.title).toEqual('Cool resources');
         });
@@ -105,7 +106,7 @@ describe('/user/:id', () => {
   describe('GET', () => {
     it('gets collection by userId', () => {
       return request(server)
-        .get('/api/collections/user/5ee987670ca9dc164756f5bd')
+        .get('/api/collections/user/5ef543db5ab0a24edef2aaa3')
         .expect(200);
     });
   });

--- a/server/jest.config.js
+++ b/server/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testEnvironment: 'node',
+};

--- a/server/package.json
+++ b/server/package.json
@@ -7,7 +7,7 @@
     "server": "nodemon server.js",
     "react": "cd ../client && npm run react",
     "start": "concurrently \"npm run server\" \"npm run react\"",
-    "test": "jest --verbose"
+    "test": "jest --verbose --coverage"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
**server/.eslintrc.js**
- adds `jest` to `env` so vscode stops complaining

**server/__tests__/routes.js**
- deleted some users and collections in mongodb, so updating the tests to use ones that still exist
- also imports the `collection.js` code so it can be used for coverage metrics

**server/jest.config.js**
- add support for testing mongoose with jest
https://mongoosejs.com/docs/jest.html

**server/package.json**
- updates test script to show coverage information

**Testing**
- Run `npm run test` or `jest routes`

Current results
```
> jest --verbose --coverage

 PASS  __tests__/routes.js
  /
    POST
      ✓ creates a collection with provided info (771 ms)
  /:id
    PUT
      ✓ updates collection with provided info (84 ms)
      ✓ returns a 500 status if collection doesn't exist (4 ms)
    GET
      ✓ gets collection with given id (82 ms)
  /user/:id
    GET
      ✓ gets collection by userId (84 ms)

-----------------|---------|----------|---------|---------|------------------------------------------------------------
File             | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s                                          
-----------------|---------|----------|---------|---------|------------------------------------------------------------
All files        |   15.48 |        0 |       0 |   17.22 |                                                            
 models          |     100 |      100 |     100 |     100 |                                                            
  Collection.js  |     100 |      100 |     100 |     100 |                                                            
  user.js        |     100 |      100 |     100 |     100 |                                                            
 routes/api      |   10.69 |        0 |       0 |   11.97 |                                                            
  collections.js |   10.69 |        0 |       0 |   11.97 | ...269-285,295-316,326-345,356-368,388-397,407-423,438-447 
-----------------|---------|----------|---------|---------|------------------------------------------------------------
Test Suites: 1 passed, 1 total
Tests:       5 passed, 5 total
Snapshots:   0 total
Time:        1.813 s, estimated 2 s
Ran all test suites.
```
