### PR TITLE
fixes tests and updates other components to pass down likes

### DIFF
--- a/client/__tests__/Collection.js
+++ b/client/__tests__/Collection.js
@@ -11,24 +11,26 @@ configure({ adapter: new Adapter() });
 describe('Collection tests', () => {
   describe('Collection', () => {
     let wrapper;
-    const props = {
+    const testProps = {
       key: 544,
       id: 4354,
       title: 'Collection',
       description: 'buncha stuff',
       author: 'Veronica',
       loggedInUser: 'Sarge',
+      likes: ['5ef2b8c3d5973033a191aea2', '5ef3f1798a8800471b987bbe', '5ef7840ba4aca16282b26299'],
     };
 
     beforeAll(() => {
       wrapper = shallow(
         <Collection
-          key={props.key}
-          id={props.id}
-          title={props.title}
-          description={props.description}
-          author={props.author}
-          loggedInUser={props.loggedInUser}
+          key={testProps.key}
+          id={testProps.id}
+          title={testProps.title}
+          description={testProps.description}
+          author={testProps.author}
+          loggedInUser={testProps.loggedInUser}
+          likes={testProps.likes}
         />,
       );
     });
@@ -38,15 +40,15 @@ describe('Collection tests', () => {
     });
 
     it('renders an h1 element that displays collection title', () => {
-      expect(wrapper.find('h1').text()).toMatch(props.title);
+      expect(wrapper.find('h1').text()).toMatch(testProps.title);
     });
 
     it('renders an h3 element that displays collection description', () => {
-      expect(wrapper.find('h3').text()).toMatch(props.description);
+      expect(wrapper.find('h3').text()).toMatch(testProps.description);
     });
 
     it('displays div with name of author', () => {
-      expect(wrapper.find('div').first().text()).toMatch(props.author);
+      expect(wrapper.find('div').first().text()).toMatch(testProps.author);
     });
 
     it('displays a Link with view the collection', () => {
@@ -61,19 +63,20 @@ describe('Collection tests', () => {
     // alternate way to actually verify the components are being rendered
     // uses package: jest-enzyme
     it('renders the LikeButton and SaveButton components if logged in', () => {
-      expect(wrapper).toContainReact(<LikeButton loggedInUser={props.loggedInUser} id={props.id} />);
-      expect(wrapper).toContainReact(<SaveButton loggedInUser={props.loggedInUser} id={props.id} />);
+      expect(wrapper).toContainReact(<LikeButton loggedInUser={testProps.loggedInUser} likes={testProps.likes} id={testProps.id} />);
+      expect(wrapper).toContainReact(<SaveButton loggedInUser={testProps.loggedInUser} id={testProps.id} />);
     });
 
     it('displays message to register or login if not logged in', () => {
       wrapper = shallow(
         <Collection
-          key={props.key}
-          id={props.id}
-          title={props.title}
-          description={props.description}
-          author={props.author}
+          key={testProps.key}
+          id={testProps.id}
+          title={testProps.title}
+          description={testProps.description}
+          author={testProps.author}
           loggedInUser={null}
+          likes={testProps.likes}
         />,
       );
       expect(wrapper.text()).toMatch('Register');

--- a/client/__tests__/ExpandedCollection.js
+++ b/client/__tests__/ExpandedCollection.js
@@ -67,16 +67,21 @@ describe('ExpandedCollection tests', () => {
   });
 
   it('displays Like and Save buttons if logged in', () => {
-    expect(wrapper.find('button')).toHaveLength(2);
-    expect(wrapper.text()).toMatch('Like Collection');
-    expect(wrapper.text()).toMatch('Save Collection');
+    expect(wrapper.find('span')).toHaveLength(2);
+    expect(wrapper.find('span').at(0).text()).toMatch(`${testData.likes.length}`);
+    expect(wrapper.find('span').at(1).text()).toMatch('Save Collection');
   });
 
   // alternate way to actually verify the components are being rendered
   // uses package: jest-enzyme
   it('renders LikeButton and SaveButton components if logged in', () => {
-    expect(wrapper).toContainReact(<LikeButton loggedInUser={testProps.loggedInUser} id={testProps.id} />);
-    expect(wrapper).toContainReact(<SaveButton loggedInUser={testProps.loggedInUser} id={testProps.id} />);
+    // expect(wrapper).toContainReact(<LikeButton loggedInUser={testProps.loggedInUser} likes={testData.likes} id={testProps.id} />);
+    // expect(wrapper).toContainReact(<SaveButton loggedInUser={testProps.loggedInUser} id={testProps.id} />);
+    expect(wrapper.find('LikeButton')).toHaveProp('loggedInUser', testProps.loggedInUser);
+    expect(wrapper.find('LikeButton')).toHaveProp('likes', []);
+    expect(wrapper.find('LikeButton')).toHaveProp('id', testProps.id);
+    expect(wrapper.find('SaveButton')).toHaveProp('loggedInUser', testProps.loggedInUser);
+    expect(wrapper.find('SaveButton')).toHaveProp('id', testProps.id);
   });
 
   it('displays message to register or login if not logged in', async () => {

--- a/client/__tests__/LikeButton.js
+++ b/client/__tests__/LikeButton.js
@@ -12,24 +12,27 @@ describe('React unit tests', () => {
     const props = {
       loggedInUser: '5ef3f1798a8800471b987bbe', // userId
       id: '5eee5bac1e986de551d57488', // collectionId
+      likes: ['5ef3f1798a8800471b987bbe'],
     };
 
     beforeAll(() => {
-      wrapper = shallow(<LikeButton loggedInUser={props.loggedInUser} id={props.id} />);
+      wrapper = shallow(<LikeButton loggedInUser={props.loggedInUser} likes={props.likes} id={props.id} />);
+      console.log('wrapper.html', wrapper.html());
+      console.log('wrapper.text', wrapper.text());
     });
 
-    it('Renders a <button> tag with the label "Like Collection"', () => {
-      expect(wrapper.type()).toEqual('button');
-      expect(wrapper.text()).toMatch('Like Collection');
+    it('Renders a <span> tag with the label "Like Collection"', () => {
+      expect(wrapper.find('span')).toHaveLength(1);
+      expect(wrapper.find('span').text()).toMatch(String(props.likes.length));
     });
 
-    it('Invokes the click handler when the Like button is pressed', () => {
+    it('Invokes the click handler when the Like button is cliked', () => {
       const mockFetch = jest.fn(() => Promise.resolve({
         status: 200,
         json: () => ['5ef2b8c3d5973033a191aea2', '5ef3f1798a8800471b987bbe'],
       }));
       global.fetch = mockFetch;
-      wrapper.find('.button-like').simulate('click');
+      wrapper.find('.button-like').props().onClick({ key: 'Enter' });
       expect(mockFetch).toHaveBeenCalled();
       expect(mockFetch.mock.calls.length).toBe(1);
 
@@ -44,10 +47,16 @@ describe('React unit tests', () => {
       expect(mockFetch).toHaveBeenCalledWith(arg1, arg2);
     });
 
-    it('Invokes the click handler when the Like button is pressed (error path)', () => {
+    it('Invokes the click handler when the Like button is clicked (error path)', () => {
       const mockFetch = jest.fn(() => Promise.reject(new Error('should catch this error')));
       global.fetch = mockFetch;
-      wrapper.find('.button-like').simulate('click');
+      wrapper.find('.button-like').props().onClick({ key: 'Enter' });
+    });
+
+    it('Invokes the click handler when the Save button is keypressed (error path)', () => {
+      const mockFetch = jest.fn(() => Promise.reject(new Error('should catch this error')));
+      global.fetch = mockFetch;
+      wrapper.find('.button-like').props().onKeyPress({ key: 'Enter' });
     });
   });
 });

--- a/client/__tests__/SaveButton.js
+++ b/client/__tests__/SaveButton.js
@@ -19,18 +19,18 @@ describe('React unit tests', () => {
     });
 
     it('Renders a <button> tag with the label "Save Collection"', () => {
-      expect(wrapper.type()).toEqual('button');
+      expect(wrapper.type()).toEqual('span');
       expect(wrapper.text()).toMatch('Save Collection');
     });
 
-    it('Invokes the click handler when the Save button is pressed (success path)', () => {
+    it('Invokes the click handler when the Save button is clicked (success path)', () => {
       const mockFetch = jest.fn(() => Promise.resolve({
         status: 200,
         json: () => ['5ef2b8c3d5973033a191aea2', '5ef3f1798a8800471b987bbe'],
       }));
       global.fetch = mockFetch;
 
-      wrapper.find('.button-like').simulate('click');
+      wrapper.find('.button-like').props().onClick({ key: 'Enter' });
       expect(mockFetch).toHaveBeenCalled();
       expect(mockFetch).toHaveBeenCalledTimes(1);
 
@@ -45,10 +45,16 @@ describe('React unit tests', () => {
       expect(mockFetch).toHaveBeenCalledWith(arg1, arg2);
     });
 
-    it('Invokes the click handler when the Save button is pressed (error path)', () => {
+    it('Invokes the click handler when the Save button is clicked (error path)', () => {
       const mockFetch = jest.fn(() => Promise.reject(new Error('should catch this error')));
       global.fetch = mockFetch;
-      wrapper.find('.button-like').simulate('click');
+      wrapper.find('.button-like').props().onClick({ key: 'Enter' });
+    });
+
+    it('Invokes the click handler when the Save button is keypressed (error path)', () => {
+      const mockFetch = jest.fn(() => Promise.reject(new Error('should catch this error')));
+      global.fetch = mockFetch;
+      wrapper.find('.button-like').props().onKeyPress({ key: 'Enter' });
     });
   });
 });

--- a/client/__tests__/__snapshots__/Collection.js.snap
+++ b/client/__tests__/__snapshots__/Collection.js.snap
@@ -39,6 +39,13 @@ exports[`Collection tests Collection renders correctly 1`] = `
     <br />
     <LikeButton
       id={4354}
+      likes={
+        Array [
+          "5ef2b8c3d5973033a191aea2",
+          "5ef3f1798a8800471b987bbe",
+          "5ef7840ba4aca16282b26299",
+        ]
+      }
       loggedInUser="Sarge"
     />
     <SaveButton

--- a/client/src/components/collections/Collection.jsx
+++ b/client/src/components/collections/Collection.jsx
@@ -7,7 +7,7 @@ import SaveButton from './SaveButton';
 import './Collection.css';
 
 const Collection = ({
-  id, title, description, author, loggedInUser, likes
+  id, title, description, author, loggedInUser, likes,
 }) => (
   <div key={id} className="collection">
     <h1 className="collection__title">{title}</h1>

--- a/client/src/components/collections/ExpandedCollection.jsx
+++ b/client/src/components/collections/ExpandedCollection.jsx
@@ -8,7 +8,7 @@ import SaveButton from './SaveButton';
 
 const ExpandedCollection = ({ loggedInUser }) => {
   // console.log('Invoked ExpandedCollection', loggedInUser);
-  const [collection, setCollection] = useState([]);
+  const [collection, setCollection] = useState({ likes: [] });
   const { id } = useParams();
 
   // console.log('useState collection', collection);
@@ -50,7 +50,7 @@ const ExpandedCollection = ({ loggedInUser }) => {
       {loggedInUser ? (
         <div>
           <br />
-          <LikeButton loggedInUser={loggedInUser} id={id} />
+          <LikeButton loggedInUser={loggedInUser} likes={collection.likes} id={id} />
           <SaveButton loggedInUser={loggedInUser} id={id} />
         </div>
       ) : (

--- a/client/src/components/collections/LikeButton.jsx
+++ b/client/src/components/collections/LikeButton.jsx
@@ -3,7 +3,6 @@ import React, { useState } from 'react';
 import './LikeButton.css';
 
 const LikeButton = ({ id, loggedInUser, likes }) => {
-
   function likeButtonClick(eventId, userId) {
     const payload = { id: userId, collectionId: id };
 
@@ -26,12 +25,15 @@ const LikeButton = ({ id, loggedInUser, likes }) => {
   return (
     <>
       <span
-      onClick={() => likeButtonClick(id, loggedInUser, likes)} 
-      type="button" 
-      className="button-like" 
+        onClick={() => likeButtonClick(id, loggedInUser, likes)}
+        onKeyPress={() => likeButtonClick(id, loggedInUser, likes)}
+        type="button"
+        className="button-like"
+        role="button"
+        tabIndex={0}
       >
         <i className="far fa-thumbs-up" />
-      &nbsp; <small>{likes.length}</small>
+        <small>{likes.length}</small>
       </span>
     </>
   );

--- a/client/src/components/collections/SaveButton.jsx
+++ b/client/src/components/collections/SaveButton.jsx
@@ -21,7 +21,14 @@ const SaveButton = ({ id, loggedInUser }) => {
   }
 
   return (
-    <span onClick={() => likeButtonClick(id, loggedInUser)} type="button" className="button-like">
+    <span
+      onClick={() => likeButtonClick(id, loggedInUser)}
+      onKeyPress={() => likeButtonClick(id, loggedInUser)}
+      role="button"
+      tabIndex={0}
+      type="button"
+      className="button-like"
+    >
       <i className="far fa-star" />
     &nbsp; Save Collection
     </span>


### PR DESCRIPTION
**client/__tests__/Collection.js**
- Add support for # of likes feature.  Now passes down likes as a prop to the `LikeButton` component

**client/__tests__/ExpandedCollection.js**
- Fixes element type as the `LikeButton` component now renders a `<span>` instead of a `<button>`
- Refactors the render test to check directly for props being passed down to the `LikeButton` and `SaveButton` components

**client/__tests__/LikeButton.js**
- Add support for the # of likes feature
- Change to look for a `<span>` instead of a `<button>`
- Switch from using `.simulate()` to using `props()` event
- Adds a test to check for `onKeyPress`

**client/__tests__/SaveButton.js**
- Change to look for a `<span>` instead of a `<button>`
- Switch from using `.simulate()` to using `props()` event
- Adds a test to check for `onKeyPress`

**client/src/components/collections/Collection.jsx**
- minor linter issue with trailing comma

**client/src/components/collections/ExpandedCollection.jsx**
- Add support for # of likes feature.  Now passes down likes as a prop to the `LikeButton` component

**client/src/components/collections/LikeButton.jsx**
**client/src/components/collections/SaveButton.jsx**
- Fix some linter issues around roles and accessibility (`keyPress`, `tabIndex`)

**Testing**
- Run `npm run test` or `jest <component>`
